### PR TITLE
Define a Docker image for `riskquant`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Use 3.7 because setup.py currently specifies python_requires='>=3.5, <3.8'
+FROM python:3.7-buster
+
+RUN mkdir -p /src
+WORKDIR /src
+COPY . /src/
+
+RUN pip install .
+RUN python setup.py install
+
+ENTRYPOINT ["/src/build/scripts-3.7/riskquant"]

--- a/README.md
+++ b/README.md
@@ -143,6 +143,35 @@ Optional argument:
 --plot : Generate Loss Exceedance Curve [ default true ]
 ```
 
+### Using riskquant via Docker
+
+Here's how to build and run `riskquant` using Docker.
+
+First, build the image locally:
+
+```
+docker build -t riskquant .
+```
+
+This step only needs to be done once for a given version of riskquant.
+
+Then, assuming your inputs are in a `data` sub-directory, you can analyze it with riskquant using a command like:
+
+```
+docker container run --rm -it \
+  -v "$(PWD)/data/":/data/ \
+  riskquant --file /data/input.csv
+```
+
+When running `riskquant` via Docker, Docker needs to mount a local directory into the container so that 
+`riskquant` can read inputs *from* and write outputs *to* that directory.  This command mounts the local `data` 
+directory into the container at `/data`.  The `--file` option tells `riskquant` where to find the file when 
+running inside the container.  You can pass other options to `riskquant` just like normal, including `--help`.
+
+Now, check the analysis results with a command like:
+```
+cat data/input_prioritized.csv
+```
 
 ### Uniqueness of identifiers
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ docker build -t riskquant .
 
 This step only needs to be done once for a given version of riskquant.
 
-Then, assuming your inputs are in a `data` sub-directory, you can analyze it with riskquant using a command like:
+Then, assuming your inputs are in a `data` sub-directory, you can analyze them with `riskquant` using a command like:
 
 ```
 docker container run --rm -it \


### PR DESCRIPTION
I created a Docker image for `riskquant` so that I could run it inside a container.  I had trouble installing `riskquant` on OSX (Python 3.6 in venv, fwiw), but I succeeded going this route and wanted to share it.  Thank you for publishing riskquant!

Here's how to build and run riskquant using Docker.  I'm happy to update the README if you're interested in supporting Docker.

Build the image:
```
docker build -t riskquant .
```

Run riskquant inside a container:
```
docker container run --rm -it   -v "$(PWD)/data":/data/  riskquant --file /data/webapp.threat-model.csv
```

Check the results:
```
cat data/webapp.threat-model_prioritized.csv
```