### PR TITLE
Remove probability assertion, relabel p->frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The inputs to simpleloss are as follows:
 
 ```python
 >> from riskquant import simpleloss
->> s = simpleloss.SimpleLoss(label="ALICE", name="Alice steals the data", p=0.10, low_loss=100000, high_loss=1000000)
+>> s = simpleloss.SimpleLoss(label="ALICE", name="Alice steals the data", frequency=0.10, low_loss=100000, high_loss=1000000)
 >> s.annualized_loss()
 
 40400.128269457266

--- a/riskquant/simpleloss.py
+++ b/riskquant/simpleloss.py
@@ -34,16 +34,16 @@ import numpy as np
 
 
 class SimpleLoss:
-    def __init__(self, label, name, p, low_loss, high_loss):
-        if not 0. <= p <= 1.:
-            # Probabilities must be in the range [0, 1]
+    def __init__(self, label, name, frequency, low_loss, high_loss):
+        if frequency < 0:
+            # Frequency must be non-negative
             raise AssertionError
         if low_loss >= high_loss:
             # High loss must exceed low loss
             raise AssertionError
         self.label = label
         self.name = name
-        self.p = p
+        self.frequency = frequency
         self.low_loss = low_loss
         self.high_loss = high_loss
 
@@ -58,7 +58,7 @@ class SimpleLoss:
 
         :returns: Scalar of expected mean loss on an annualized basis."""
 
-        return self.p * self.distribution.mean()
+        return self.frequency * self.distribution.mean()
 
     def single_loss(self):
         """Draw a single loss amount. Not scaled by probability of occurrence.
@@ -71,7 +71,7 @@ class SimpleLoss:
         """Generate a random number of losses, and loss amount for each.
 
         :returns: List of loss amounts, or empty list if no loss occurred."""
-        num_losses = np.random.poisson(self.p, 1)[0]
+        num_losses = np.random.poisson(self.frequency, 1)[0]
         return [self.single_loss() for _ in range(num_losses)]
 
     def simulate_years(self, n):
@@ -80,7 +80,7 @@ class SimpleLoss:
         :arg: n = Number of years to simulate
         :returns: List of length n with loss amounts per year. Amount is 0 if no loss occurred."""
         # Generate a loss count (of value 0+) for each year being simulated
-        losses_each_year = np.random.poisson(self.p, n)
+        losses_each_year = np.random.poisson(self.frequency, n)
         # The total number of loss events across all years
         total_loss_count = sum(losses_each_year)
         # The loss amounts for all the losses across all the years, generated all at once.

--- a/tests/test_riskquant.py
+++ b/tests/test_riskquant.py
@@ -31,7 +31,7 @@ class TestRiskquant(unittest.TestCase):
         path = TestRiskquant._write_to_tempfile(csvdata)
         losses = riskquant.csv_to_simpleloss(path)
         for i in range(len(expected)):
-            loss = (losses[i].label, losses[i].name, losses[i].p,
+            loss = (losses[i].label, losses[i].name, losses[i].frequency,
                     losses[i].low_loss, losses[i].high_loss)
             for j in range(5):
                 self.assertEqual(loss[j], expected[i][j])

--- a/tests/test_simpleloss.py
+++ b/tests/test_simpleloss.py
@@ -27,7 +27,7 @@ class Test(unittest.TestCase):
     def testVariables(self):
         self.assertEqual(self.s.label, 'L1')
         self.assertEqual(self.s.name, 'loss_name')
-        self.assertEqual(self.s.p, 0.1)
+        self.assertEqual(self.s.frequency, 0.1)
         self.assertEqual(self.s.low_loss, 1)
         self.assertEqual(self.s.high_loss, 10)
 
@@ -35,6 +35,10 @@ class Test(unittest.TestCase):
         # Returns the mean of the configured distribution scaled by the probability
         # of occurrence p
         self.assertAlmostEqual(self.s.annualized_loss(), 0.4040012826945718)
+
+    def testLargeFrequency(self):
+        lg = simpleloss.SimpleLoss('Large', 'large_loss', 3.0, 1, 10)
+        self.assertAlmostEqual(lg.annualized_loss(), 12.120038480837177)  # 30x the value above
 
     def testDistribution(self):
         # We defined the cdf(low) ~ 0.05 and the cdf(hi) ~ 0.95 so that
@@ -77,23 +81,8 @@ class Test(unittest.TestCase):
         self.assertAlmostEqual(hard.annualized_loss(), 414589.4783457917)
 
     def testContract(self):
-        # Probability must be <= 1.
-        try:
-            simpleloss.SimpleLoss("L2", "loss2", 10, 100, 1000)  # p > 1
-            self.fail("Probability <= 1. not enforced")
-        except AssertionError:
-            pass
-
-        # Probability must be >= 0.
-        try:
-            simpleloss.SimpleLoss("L2", "loss2", -1, 100, 1000)  # p < 0
-            self.fail("Probability >= 0. not enforced")
-        except AssertionError:
-            pass
+        # Frequency must be >= 0.
+        self.assertRaises(AssertionError, simpleloss.SimpleLoss, "L2", "loss2", -1, 100, 1000)
 
         # High loss must exceed low loss
-        try:
-            simpleloss.SimpleLoss("L2", "loss2", 0.5, 1000, 100)  # low_loss > high_loss
-            self.fail("low_loss <= high_loss not enforced")
-        except AssertionError:
-            pass
+        self.assertRaises(AssertionError, simpleloss.SimpleLoss, "L2", "loss2", 0.5, 1000, 100)


### PR DESCRIPTION
An old assertion that required the frequency parameter to be in the range [0, 1] is obsolete because it's actually a frequency defined on the range [0, Infinity]. This PR fixes the behavior and changes the name of the parameter to "frequency".

For users that are using named parameters for SimpleLoss, note that the name change could break your code, please update the parameter name as noted above.