### PR TITLE
Create a flexible Loss class to contain frequency, magnitude models

### DIFF
--- a/riskquant/loss.py
+++ b/riskquant/loss.py
@@ -1,0 +1,46 @@
+"""A generic loss container that can be populated with different models.
+"""
+
+#   Copyright 2019-2020 Netflix, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+class Loss(object):
+    def __init__(self, frequency_model, magnitude_model):
+        """:param frequency_model: A class with method draw(n=1) to draw a list of n int values
+        :param magnitude_model: A class with method draw(n=1) to draw a list of n float values
+        """
+        self.frequency_model = frequency_model
+        self.magnitude_model = magnitude_model
+
+    def annualized_loss(self):
+        return self.frequency_model.mean() * self.magnitude_model.mean()
+
+    def simulate_losses_one_year(self):
+        """:return List of zero or more loss magnitudes for a single simulated year"""
+        num_losses = self.frequency_model.draw()[0]  # Draw a single number of events
+        return list(self.magnitude_model.draw(num_losses))
+
+    def simulate_years(self, n):
+        """:param n = Number of years to simulate
+        :return A list of length n, each entry is the sum of losses for that simulated year"""
+        num_losses = self.frequency_model.draw(n)  # Draw a list of the number of events in each year
+        loss_values = self.magnitude_model.draw(sum(num_losses))
+        losses = [0] * n
+        losses_used = 0
+        for i in range(n):
+            new_losses = num_losses[i]
+            losses[i] = sum(loss_values[losses_used:losses_used + new_losses])
+            losses_used += new_losses
+        return losses

--- a/riskquant/model/lognormal_magnitude.py
+++ b/riskquant/model/lognormal_magnitude.py
@@ -1,0 +1,54 @@
+"""A magnitude model based on the lognormal distribution define by a 90% confidence interval
+"""
+
+#   Copyright 2019-2020 Netflix, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import math
+from scipy.stats import norm
+from scipy.stats import lognorm
+
+
+class LognormalMagnitude(object):
+    def __init__(self, low_loss, high_loss):
+        """:param  low_loss = Low loss estimate
+        :param high_loss = High loss estimate
+
+        The range low_loss -> high_loss should represent the 90% confidence interval
+        that the loss will fall in that range.
+
+        These values are then fit to a lognormal distribution so that they fall at the 5% and
+        95% cumulative probability points.
+        """
+        if low_loss >= high_loss:
+            # High loss must exceed low loss
+            raise AssertionError
+        self.low_loss = low_loss
+        self.high_loss = high_loss
+        self._setup_lognormal(low_loss, high_loss)
+
+    def _setup_lognormal(self, low_loss, high_loss):
+        # Set up the lognormal distribution
+        factor = -0.5 / norm.ppf(0.05)
+        mu = (math.log(low_loss) + math.log(high_loss)) / 2.  # Average of the logn of low/high
+        shape = factor * (math.log(high_loss) - math.log(low_loss))  # Standard deviation
+        self.distribution = lognorm(shape, scale=math.exp(mu))
+
+    def draw(self, n=1):
+        return self.distribution.rvs(size=n)
+
+    def mean(self):
+        return self.distribution.mean()
+
+

--- a/riskquant/model/poisson_frequency.py
+++ b/riskquant/model/poisson_frequency.py
@@ -1,0 +1,32 @@
+"""A Poisson model suitable for frequency. Returns an array of ints.
+"""
+
+#   Copyright 2019-2020 Netflix, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import numpy as np
+
+
+class PoissonFrequency(object):
+    def __init__(self, frequency):
+        """:param frequency = Mean rate per interval"""
+        if frequency < 0:
+            raise AssertionError("Frequency must be non-negative.")
+        self.frequency = frequency
+
+    def draw(self, n=1):
+        return np.random.poisson(self.frequency, n)
+
+    def mean(self):
+        return self.frequency

--- a/riskquant/simpleloss.py
+++ b/riskquant/simpleloss.py
@@ -26,78 +26,18 @@ distribution so that they fall at the 5% and 95% cumulative probability points.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import math
-
-from scipy.stats import norm
-from scipy.stats import lognorm
-import numpy as np
+from riskquant import loss
+from riskquant.model import poisson_frequency, lognormal_magnitude
 
 
-class SimpleLoss:
+class SimpleLoss(loss.Loss):
     def __init__(self, label, name, frequency, low_loss, high_loss):
-        if frequency < 0:
-            # Frequency must be non-negative
-            raise AssertionError
-        if low_loss >= high_loss:
-            # High loss must exceed low loss
-            raise AssertionError
         self.label = label
         self.name = name
         self.frequency = frequency
         self.low_loss = low_loss
         self.high_loss = high_loss
+        super(SimpleLoss, self).__init__(
+            poisson_frequency.PoissonFrequency(frequency),
+            lognormal_magnitude.LognormalMagnitude(low_loss, high_loss))
 
-        # Set up the lognormal distribution
-        factor = -0.5 / norm.ppf(0.05)
-        mu = (math.log(low_loss) + math.log(high_loss)) / 2.  # Average of the logn of low/high
-        shape = factor * (math.log(high_loss) - math.log(low_loss))  # Standard deviation
-        self.distribution = lognorm(shape, scale=math.exp(mu))
-
-    def annualized_loss(self):
-        """Expected mean loss per year as scaled by the probability of occurrence
-
-        :returns: Scalar of expected mean loss on an annualized basis."""
-
-        return self.frequency * self.distribution.mean()
-
-    def single_loss(self):
-        """Draw a single loss amount. Not scaled by probability of occurrence.
-
-        :returns: Scalar value of a randomly generated single loss amount."""
-
-        return self.distribution.rvs()
-
-    def simulate_losses_one_year(self):
-        """Generate a random number of losses, and loss amount for each.
-
-        :returns: List of loss amounts, or empty list if no loss occurred."""
-        num_losses = np.random.poisson(self.frequency, 1)[0]
-        return [self.single_loss() for _ in range(num_losses)]
-
-    def simulate_years(self, n):
-        """Draw randomly to simulate n years of possible losses.
-
-        :arg: n = Number of years to simulate
-        :returns: List of length n with loss amounts per year. Amount is 0 if no loss occurred."""
-        # Generate a loss count (of value 0+) for each year being simulated
-        losses_each_year = np.random.poisson(self.frequency, n)
-        # The total number of loss events across all years
-        total_loss_count = sum(losses_each_year)
-        # The loss amounts for all the losses across all the years, generated all at once.
-        # This is much higher performance than generating one year at a time.
-        all_losses = self.distribution.rvs(size=total_loss_count)
-        # Create a list of len(n) with the sum of losses in each simulated year.
-        i = 0
-        year = 0
-        result = []
-        while year < len(losses_each_year):
-            losses_this_year = losses_each_year[year]
-            # Extend the result list by the sum of losses that occurred in this simulated
-            # year. Here we are drawing 'losses_this_year' loss events from the all_losses
-            # list and summing just those.
-            result += [sum(all_losses[i:i + losses_this_year])]
-            # Iterate the offset into the all_losses array
-            i += losses_this_year
-            # Iterate the year being examined.
-            year += 1
-        return result

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,0 +1,42 @@
+import unittest
+
+from riskquant import loss
+
+
+class FixedValueModel(object):
+    def __init__(self, value):
+        self.value = value
+
+    def draw(self, n=1):
+        return [self.value] * n
+
+
+class TestLoss(unittest.TestCase):
+    def test_simulate_losses_one_year(self):
+        loss_model = loss.Loss(FixedValueModel(1), FixedValueModel(0.5))
+        single_loss = loss_model.simulate_losses_one_year()
+        self.assertEqual([0.5], single_loss)
+
+    def test_simulate_losses_one_year_multiple_loss(self):
+        loss_model = loss.Loss(FixedValueModel(3), FixedValueModel(0.5))
+        single_loss = loss_model.simulate_losses_one_year()
+        self.assertEqual([0.5, 0.5, 0.5], single_loss)
+
+    def test_simulate_years(self):
+        loss_model = loss.Loss(FixedValueModel(1), FixedValueModel(0.5))
+        multiple_years = loss_model.simulate_years(3)
+        self.assertEqual([0.5, 0.5, 0.5], multiple_years)
+
+    def test_simulate_years_frequency(self):
+        loss_model = loss.Loss(FixedValueModel(2), FixedValueModel(0.5))
+        multiple_years = loss_model.simulate_years(3)
+        self.assertEqual([1.0, 1.0, 1.0], multiple_years)
+
+    def test_simulate_zeros(self):
+        loss_model = loss.Loss(FixedValueModel(0), FixedValueModel(0.5))
+        multiple_years = loss_model.simulate_years(3)
+        self.assertEqual([0, 0, 0], multiple_years)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_model_lognormal.py
+++ b/tests/test_model_lognormal.py
@@ -1,0 +1,24 @@
+import unittest
+
+from riskquant.model import lognormal_magnitude
+
+
+class MyTestCase(unittest.TestCase):
+    def setUp(self):
+        self.l = lognormal_magnitude.LognormalMagnitude(1, 10)
+
+    def testDistribution(self):
+        # We defined the cdf(low) ~ 0.05 and the cdf(hi) ~ 0.95 so that
+        # it would be the 90% confidence interval. Check that it's true.
+        self.assertTrue(0.049 < self.l.distribution.cdf(1) < 0.051)
+        self.assertTrue(0.949 < self.l.distribution.cdf(10) < 0.951)
+
+    def testHardParameters(self):
+        # Test difficult-to-fit parameter values
+        hard = lognormal_magnitude.LognormalMagnitude(635000, 19000000)
+        self.assertAlmostEqual(5922706.83351131, hard.mean())
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
We would like people to be able to use arbitrary frequency and loss models, but there would have been a proliferation of special cases unless we do something like this to create a generic loss model container.

I also converted the SimpleLoss class to inherit from the new Loss class, to show how it's done. If this makes sense to you, then I'll convert the PERT loss model in the next PR to use the same mechanism.

I also moved the models themselves into a model subdirectory so that we can add more frequency and magnitude models there.